### PR TITLE
add network_bitrate.sh (bash script)

### DIFF
--- a/network_bitrate.sh
+++ b/network_bitrate.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+INTERFACES_SYS_DIR="/sys/class/net"
+
+get_total_bytes() {
+    STATS_BYTES=$1
+    BYTES=0
+
+    for IFACE in $(ls $INTERFACES_SYS_DIR)
+    do
+        [[ $IFACE == "lo" ]] && continue
+        BYTES=$((BYTES + $(cat $INTERFACES_SYS_DIR/$IFACE/statistics/$STATS_BYTES)))
+    done
+    echo "$BYTES"
+}
+
+# Entry point
+case $1 in
+    "download") STATS_BYTES="rx_bytes"; ;;
+    "upload") STATS_BYTES="tx_bytes"; ;;
+    *) echo "Error: invalid parameter"; exit 1; ;;
+esac
+
+# run
+SAMPLE1=$(get_total_bytes $STATS_BYTES)
+sleep 1
+SAMPLE2=$(get_total_bytes $STATS_BYTES)
+
+BITRATE=$(((${SAMPLE2} - ${SAMPLE1}) * 8))
+echo "$BITRATE"


### PR DESCRIPTION
New bash script to calculate global bit rate of all network interfaces (excluding loopback).
Script must be invoked specifying `download` or `upload` parameter

example:

```bash
bash network_bitrate.sh download
```